### PR TITLE
Fix rubocop config file

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@
 
 AllCops:
   TargetRubyVersion: 2.7.0
+  NewCops: 'enable'
   Exclude:
     - 'bin/*'
     - 'config/initializers/backtrace_silencers.rb'
@@ -24,12 +25,6 @@ Layout/LineLength:
   URISchemes:
     - http
     - https
-
-Layout/EmptyLinesAroundAttributeAccessor:
-  Enabled: true
-
-Layout/SpaceAroundMethodCallOperator:
-  Enabled: true
 
 # Metrics cops
 
@@ -83,30 +78,6 @@ Style/FrozenStringLiteralComment:
 Style/ModuleFunction:
   Enabled: false
 
-Style/ExponentialNotation:
-  Enabled: true
-
-Style/HashEachMethods:
-  Enabled: true
-
-Style/HashTransformKeys:
-  Enabled: true
-
-Style/HashTransformValues:
-  Enabled: true
-
-Style/RedundantFetchBlock:
-  Enabled: true
-
-Style/RedundantRegexpCharacterClass:
-  Enabled: true
-
-Style/RedundantRegexpEscape:
-  Enabled: true
-
-Style/SlicingWithRange:
-  Enabled: true
-
 Style/SymbolArray:
   Enabled: false
 
@@ -115,15 +86,3 @@ Style/SymbolArray:
 Lint/AmbiguousBlockAssociation:
   Exclude:
     - spec/**/*
-
-Lint/DeprecatedOpenSSLConstant:
-  Enabled: true
-
-Lint/MixedRegexpCaptureTypes:
-  Enabled: true
-
-Lint/RaiseException:
-  Enabled: true
-
-Lint/StructNewOverride:
-  Enabled: true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,7 +81,7 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
   if ENV['RAILS_LOG_TO_STDOUT'].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger           = ActiveSupport::Logger.new($stdout)
     logger.formatter = config.log_formatter
     config.logger    = ActiveSupport::TaggedLogging.new(logger)
   end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -4,13 +4,13 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-max_threads_count = ENV.fetch('RAILS_MAX_THREADS') { 5 }
+max_threads_count = ENV.fetch('RAILS_MAX_THREADS', 5)
 min_threads_count = ENV.fetch('RAILS_MIN_THREADS') { max_threads_count }
 threads min_threads_count, max_threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port        ENV.fetch('PORT') { 3000 }
+port        ENV.fetch('PORT', 3000)
 
 # Specifies the `environment` that Puma will run in.
 #


### PR DESCRIPTION
# 🤖  Rubocop update
Included new cops that caused warnings. All the cops were enabled by default, but were cluttering the output of rubocop with warnings.
Also arranged them in a more readable fashion.